### PR TITLE
Moved test targets into separate schemes

### DIFF
--- a/Mustache.xcodeproj/xcshareddata/xcschemes/MustacheOSX.xcscheme
+++ b/Mustache.xcodeproj/xcshareddata/xcschemes/MustacheOSX.xcscheme
@@ -20,20 +20,6 @@
                ReferencedContainer = "container:Mustache.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "561E72651A8BDC2B004ED48B"
-               BuildableName = "MustacheOSXTests.xctest"
-               BlueprintName = "MustacheOSXTests"
-               ReferencedContainer = "container:Mustache.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -43,16 +29,6 @@
       codeCoverageEnabled = "YES"
       buildConfiguration = "Debug">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "561E72651A8BDC2B004ED48B"
-               BuildableName = "MustacheOSXTests.xctest"
-               BlueprintName = "MustacheOSXTests"
-               ReferencedContainer = "container:Mustache.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/Mustache.xcodeproj/xcshareddata/xcschemes/MustacheOSXTests.xcscheme
+++ b/Mustache.xcodeproj/xcshareddata/xcschemes/MustacheOSXTests.xcscheme
@@ -9,14 +9,14 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "563AE19619FBE47A0028C6C1"
-               BuildableName = "Mustache.framework"
-               BlueprintName = "MustacheiOS"
+               BlueprintIdentifier = "561E72651A8BDC2B004ED48B"
+               BuildableName = "MustacheOSXTests.xctest"
+               BlueprintName = "MustacheOSXTests"
                ReferencedContainer = "container:Mustache.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -29,13 +29,23 @@
       codeCoverageEnabled = "YES"
       buildConfiguration = "Debug">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "561E72651A8BDC2B004ED48B"
+               BuildableName = "MustacheOSXTests.xctest"
+               BlueprintName = "MustacheOSXTests"
+               ReferencedContainer = "container:Mustache.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "563AE19619FBE47A0028C6C1"
+            BlueprintIdentifier = "561E725B1A8BDC2B004ED48B"
             BuildableName = "Mustache.framework"
-            BlueprintName = "MustacheiOS"
+            BlueprintName = "MustacheOSX"
             ReferencedContainer = "container:Mustache.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -55,9 +65,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "563AE19619FBE47A0028C6C1"
-            BuildableName = "Mustache.framework"
-            BlueprintName = "MustacheiOS"
+            BlueprintIdentifier = "561E72651A8BDC2B004ED48B"
+            BuildableName = "MustacheOSXTests.xctest"
+            BlueprintName = "MustacheOSXTests"
             ReferencedContainer = "container:Mustache.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -70,15 +80,6 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "563AE19619FBE47A0028C6C1"
-            BuildableName = "Mustache.framework"
-            BlueprintName = "MustacheiOS"
-            ReferencedContainer = "container:Mustache.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Mustache.xcodeproj/xcshareddata/xcschemes/MustacheiOSTests.xcscheme
+++ b/Mustache.xcodeproj/xcshareddata/xcschemes/MustacheiOSTests.xcscheme
@@ -9,14 +9,14 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "563AE19619FBE47A0028C6C1"
-               BuildableName = "Mustache.framework"
-               BlueprintName = "MustacheiOS"
+               BlueprintIdentifier = "563AE1A119FBE47A0028C6C1"
+               BuildableName = "MustacheiOSTests.xctest"
+               BlueprintName = "MustacheiOSTests"
                ReferencedContainer = "container:Mustache.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -29,6 +29,16 @@
       codeCoverageEnabled = "YES"
       buildConfiguration = "Debug">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "563AE1A119FBE47A0028C6C1"
+               BuildableName = "MustacheiOSTests.xctest"
+               BlueprintName = "MustacheiOSTests"
+               ReferencedContainer = "container:Mustache.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -55,9 +65,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "563AE19619FBE47A0028C6C1"
-            BuildableName = "Mustache.framework"
-            BlueprintName = "MustacheiOS"
+            BlueprintIdentifier = "563AE1A119FBE47A0028C6C1"
+            BuildableName = "MustacheiOSTests.xctest"
+            BlueprintName = "MustacheiOSTests"
             ReferencedContainer = "container:Mustache.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -70,15 +80,6 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "563AE19619FBE47A0028C6C1"
-            BuildableName = "Mustache.framework"
-            BlueprintName = "MustacheiOS"
-            ReferencedContainer = "container:Mustache.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
When trying to build the Swift2 branch using `carthage update`, the compiler failed on building the test target. I'm not sure why it fails to build the test target, but moving the test targets into separate schemes prevents them from being build when using Carthage, which is probably a good thing either way.

