### PR TITLE
Change Type enum names to `Type` to avoid collision errors on recent Swift

### DIFF
--- a/Sources/Context.swift
+++ b/Sources/Context.swift
@@ -215,14 +215,14 @@ final public class Context {
     // =========================================================================
     // MARK: - Not public
     
-    private enum Type {
+    private enum `Type` {
         case Root
         case Box(box: MustacheBox, parent: Context)
         case PartialOverride(partialOverride: TemplateASTNode.PartialOverride, parent: Context)
     }
     
     private var registeredKeysContext: Context?
-    private let type: Type
+    private let type: `Type`
     
     var willRenderStack: [WillRenderFunction] {
         switch type {
@@ -265,7 +265,7 @@ final public class Context {
         }
     }
     
-    private init(type: Type, registeredKeysContext: Context? = nil) {
+    private init(type: `Type`, registeredKeysContext: Context? = nil) {
         self.type = type
         self.registeredKeysContext = registeredKeysContext
     }

--- a/Sources/Logger.swift
+++ b/Sources/Logger.swift
@@ -77,13 +77,13 @@ extension StandardLibrary {
                 willRender: { (tag, box) in
                     if tag.type == .Section {
                         self.log("\(self.indentationPrefix)\(tag) will render \(box.valueDescription)")
-                        self.indentationLevel++
+                        self.indentationLevel += 1
                     }
                     return box
                 },
                 didRender: { (tag, box, string) in
                     if tag.type == .Section {
-                        self.indentationLevel--
+                        self.indentationLevel -= 1
                     }
                     if let string = string {
                         self.log("\(self.indentationPrefix)\(tag) did render \(box.valueDescription) as \(string.debugDescription)")

--- a/Sources/TemplateAST.swift
+++ b/Sources/TemplateAST.swift
@@ -35,13 +35,13 @@ final class TemplateAST {
     // become defined.
     //
     // See TemplateRepository.templateAST(named:relativeToTemplateID:error:).
-    enum Type {
+    enum `Type` {
         case Undefined
         case Defined(nodes: [TemplateASTNode], contentType: ContentType)
     }
-    var type: Type
+    var type: `Type`
     
-    private init(type: Type) {
+    private init(type: `Type`) {
         self.type = type
     }
     
@@ -50,14 +50,14 @@ final class TemplateAST {
     Returns an undefined TemplateAST.
     */
     convenience init() {
-        self.init(type: Type.Undefined)
+        self.init(type: `Type`.Undefined)
     }
     
     /**
     Returns a defined TemplateAST.
     */
     convenience init(nodes: [TemplateASTNode], contentType: ContentType) {
-        self.init(type: Type.Defined(nodes: nodes, contentType: contentType))
+        self.init(type: `Type`.Defined(nodes: nodes, contentType: contentType))
     }
     
     /**

--- a/Sources/TemplateCompiler.swift
+++ b/Sources/TemplateCompiler.swift
@@ -368,10 +368,10 @@ final class TemplateCompiler: TemplateTokenConsumer {
     }
     
     private class Scope {
-        let type: Type
+        let type: `Type`
         var templateASTNodes: [TemplateASTNode]
         
-        init(type:Type) {
+        init(type:`Type`) {
             self.type = type
             self.templateASTNodes = []
         }
@@ -380,7 +380,7 @@ final class TemplateCompiler: TemplateTokenConsumer {
             templateASTNodes.append(node)
         }
         
-        enum Type {
+        enum `Type` {
             case Root
             case Section(openingToken: TemplateToken, expression: Expression)
             case InvertedSection(openingToken: TemplateToken, expression: Expression)

--- a/Sources/TemplateParser.swift
+++ b/Sources/TemplateParser.swift
@@ -59,7 +59,7 @@ final class TemplateParser {
             case .Start:
                 if c == "\n" {
                     state = .Text(startIndex: i, startLineNumber: lineNumber)
-                    ++lineNumber
+                    lineNumber += 1
                 } else if atString(i, currentDelimiters.unescapedTagStart) {
                     state = .UnescapedTag(startIndex: i, startLineNumber: lineNumber)
                     i = i.advancedBy(currentDelimiters.unescapedTagStartLength).predecessor()
@@ -74,7 +74,7 @@ final class TemplateParser {
                 }
             case .Text(let startIndex, let startLineNumber):
                 if c == "\n" {
-                    ++lineNumber
+                    lineNumber += 1
                 } else if atString(i, currentDelimiters.unescapedTagStart) {
                     if startIndex != i {
                         let range = startIndex..<i
@@ -123,7 +123,7 @@ final class TemplateParser {
                 }
             case .Tag(let startIndex, let startLineNumber):
                 if c == "\n" {
-                    ++lineNumber
+                    lineNumber += 1
                 } else if atString(i, currentDelimiters.tagDelimiterPair.1) {
                     let tagInitialIndex = startIndex.advancedBy(currentDelimiters.tagStartLength)
                     let tagInitial = templateString[tagInitialIndex]
@@ -245,7 +245,7 @@ final class TemplateParser {
                 break
             case .UnescapedTag(let startIndex, let startLineNumber):
                 if c == "\n" {
-                    ++lineNumber
+                    lineNumber += 1
                 } else if atString(i, currentDelimiters.unescapedTagEnd) {
                     let tagInitialIndex = startIndex.advancedBy(currentDelimiters.unescapedTagStartLength)
                     let content = templateString.substringWithRange(tagInitialIndex..<i)
@@ -263,7 +263,7 @@ final class TemplateParser {
                 }
             case .SetDelimitersTag(let startIndex, let startLineNumber):
                 if c == "\n" {
-                    ++lineNumber
+                    lineNumber += 1
                 } else if atString(i, currentDelimiters.setDelimitersEnd) {
                     let tagInitialIndex = startIndex.advancedBy(currentDelimiters.setDelimitersStartLength)
                     let content = templateString.substringWithRange(tagInitialIndex..<i)

--- a/Sources/TemplateToken.swift
+++ b/Sources/TemplateToken.swift
@@ -22,7 +22,7 @@
 
 
 struct TemplateToken {
-    enum Type {
+    enum `Type` {
         /// text
         case Text(text: String)
         
@@ -60,7 +60,7 @@ struct TemplateToken {
         case Block(content: String)
     }
     
-    let type: Type
+    let type: `Type`
     let lineNumber: Int
     let templateID: TemplateID?
     let templateString: String


### PR DESCRIPTION
To fix #23, I have gone through and added back-ticks to all enums named Type as per compiler suggestion:

> note: backticks can escape this name if it is important to use

Just a quick fix to get it compiling.