### PR TITLE
Change Type enum names to `Type` to avoid collision errors on recent Swift

### DIFF
--- a/Sources/Context.swift
+++ b/Sources/Context.swift
@@ -215,7 +215,7 @@ final public class Context {
     // =========================================================================
     // MARK: - Not public
     
-    private enum Type {
+    private enum `Type` {
         case Root
         case Box(box: MustacheBox, parent: Context)
         case PartialOverride(partialOverride: TemplateASTNode.PartialOverride, parent: Context)

--- a/Sources/TemplateAST.swift
+++ b/Sources/TemplateAST.swift
@@ -35,7 +35,7 @@ final class TemplateAST {
     // become defined.
     //
     // See TemplateRepository.templateAST(named:relativeToTemplateID:error:).
-    enum Type {
+    enum `Type` {
         case Undefined
         case Defined(nodes: [TemplateASTNode], contentType: ContentType)
     }

--- a/Sources/TemplateCompiler.swift
+++ b/Sources/TemplateCompiler.swift
@@ -380,7 +380,7 @@ final class TemplateCompiler: TemplateTokenConsumer {
             templateASTNodes.append(node)
         }
         
-        enum Type {
+        enum `Type` {
             case Root
             case Section(openingToken: TemplateToken, expression: Expression)
             case InvertedSection(openingToken: TemplateToken, expression: Expression)

--- a/Sources/TemplateToken.swift
+++ b/Sources/TemplateToken.swift
@@ -22,7 +22,7 @@
 
 
 struct TemplateToken {
-    enum Type {
+    enum `Type` {
         /// text
         case Text(text: String)
         


### PR DESCRIPTION
To fix #23, I have gone through and added back-ticks to all enum _declarations_* named Type as per compiler suggestion:

> note: backticks can escape this name if it is important to use

Just a quick fix to get it compiling.

_*cleaned up per your advice_