### PR TITLE
Fix Info.plist path

### DIFF
--- a/Xcode/Mustache.xcodeproj/project.pbxproj
+++ b/Xcode/Mustache.xcodeproj/project.pbxproj
@@ -1640,7 +1640,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Mustache/Info.plist;
+				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1661,7 +1661,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Mustache/Info.plist;
+				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";


### PR DESCRIPTION
#20 

I got an error on Swift2.2 branch with Carthage.

```
$ carthage update --platform iOS
*** Cloning GRMustache.swift
*** Checking out GRMustache.swift at "0263dbf0be35b1f23e59f5b6a392fc7252476618"
*** xcodebuild output can be found in /var/folders/84/nccjqmds62g_40cvcwf7b6r00000gn/T/carthage-xcodebuild.7VVKw1.log
*** Building scheme "MustacheiOS" in Mustache.xcworkspace
** BUILD FAILED **


The following build commands failed:
	ProcessInfoPlistFile /Users/ariarijp/Library/Developer/Xcode/DerivedData/Mustache-cmjnffbsmwtkdhglddugzaqczjlt/Build/Products/Release-iphoneos/Mustache.framework/Info.plist Mustache/Info.plist
(1 failure)
error: could not read data from '/Users/ariarijp/workspace/swift/MyProject/Carthage/Checkouts/GRMustache.swift/Xcode/Mustache/Info.plist': The file “Info.plist” couldn’t be opened because there is no such file.
A shell task (/usr/bin/xcrun xcodebuild -workspace /Users/ariarijp/workspace/swift/MyProject/Carthage/Checkouts/GRMustache.swift/Xcode/Mustache.xcworkspace -scheme MustacheiOS -configuration Release -sdk iphoneos ONLY_ACTIVE_ARCH=NO BITCODE_GENERATION_MODE=bitcode CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean build) failed with exit code 65:
** BUILD FAILED **


The following build commands failed:
	ProcessInfoPlistFile /Users/ariarijp/Library/Developer/Xcode/DerivedData/Mustache-cmjnffbsmwtkdhglddugzaqczjlt/Build/Products/Release-iphoneos/Mustache.framework/Info.plist Mustache/Info.plist
(1 failure)
```

so I've fixed Info.plist path in Mustache.xcodeproj.