### PR TITLE
Fix runtime crash in Xcode 10

### DIFF
--- a/Sources/MustacheBox.swift
+++ b/Sources/MustacheBox.swift
@@ -133,7 +133,11 @@ final public class MustacheBox : NSObject {
     // MARK: - Other facets
     
     /// See the documentation of `RenderFunction`.
-    public fileprivate(set) var render: RenderFunction
+    fileprivate var renderImpl: RenderFunction
+
+    public func render(_ info: RenderingInfo) throws -> Rendering {
+        return try self.renderImpl(info)
+    }
     
     /// See the documentation of `FilterFunction`.
     public let filter: FilterFunction?
@@ -143,8 +147,8 @@ final public class MustacheBox : NSObject {
     
     /// See the documentation of `DidRenderFunction`.
     public let didRender: DidRenderFunction?
-    
-    
+
+
     // -------------------------------------------------------------------------
     // MARK: - Multi-facetted Box Initialization
     
@@ -435,7 +439,7 @@ final public class MustacheBox : NSObject {
         self.didRender = didRender
         if let render = render {
             self.hasCustomRenderFunction = true
-            self.render = render
+            self.renderImpl = render
             super.init()
         } else {
             // The default render function: it renders {{variable}} tags as the
@@ -447,10 +451,10 @@ final public class MustacheBox : NSObject {
             // We have to set self.render twice in order to avoid the compiler
             // error: "variable 'self.render' captured by a closure before being
             // initialized"
-            self.render = { (_) in return Rendering("") }
+            self.renderImpl = { (_) in return Rendering("") }
             self.hasCustomRenderFunction = false
             super.init()
-            self.render = { [unowned self] (info: RenderingInfo) in
+            self.renderImpl = { [unowned self] (info: RenderingInfo) in
                 
                 // Default rendering depends on the tag type:
                 switch info.tag.type {


### PR DESCRIPTION
```
Attempted to read an unowned reference but the object was already deallocated
```
MustacheBox.render should be a method calling, since renderImpl can not guarantee `self` is retained when called.
Detail: https://bugs.swift.org/browse/SR-8206