### PR TITLE
Update Package.swift to Swift 5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,19 @@
+// swift-tools-version:5.0
+
 import PackageDescription
 
 let package = Package(
-  name: "Mustache"
+    name: "Mustache",
+    products: [
+        .library(
+            name: "Mustache",
+            targets: ["Mustache"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "Mustache",
+            dependencies: [],
+            path: "Sources")
+    ]
 ) 


### PR DESCRIPTION
Hello,
this commits makes GRMustache usable in a Swift 5 package.

## Test this PR by creating a swift package like this:
`mkdir host`
`cd host`
`swift package init`

Package.swift:
```swift
// swift-tools-version:5.0

import PackageDescription

let package = Package(
    name: "host",
    products: [
        .library(
            name: "host",
            targets: ["host"]),
    ],
    dependencies: [
        .package(url: "https://github.com/SamuelSchepp/GRMustache.swift.git", .branch("master"))
    ],
    targets: [
        .target(
            name: "host",
            dependencies: ["Mustache"]),
        .testTarget(
            name: "hostTests",
            dependencies: ["host"]),
    ]
)
```

`swift build`