### PR TITLE
deprecated class keyword replaced with AnyObject

### DIFF
--- a/Sources/Tag.swift
+++ b/Sources/Tag.swift
@@ -53,7 +53,7 @@ public enum TagType {
 /// - seealso: RenderFunction
 /// - seealso: WillRenderFunction
 /// - seealso: DidRenderFunction
-public protocol Tag: class, CustomStringConvertible {
+public protocol Tag: AnyObject, CustomStringConvertible {
     
     // IMPLEMENTATION NOTE
     //


### PR DESCRIPTION
This PR fixes warning:
`Tag.swift:56:22: Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead`