### PR TITLE
handle file and directory name include white space

### DIFF
--- a/Sources/TemplateRepository.swift
+++ b/Sources/TemplateRepository.swift
@@ -443,8 +443,9 @@ final public class TemplateRepository {
             } else {
                 templateBaseURL = self.baseURL
             }
-            
-            let templateURL = URL(string: templateFilename, relativeTo: templateBaseURL)!.standardizedFileURL
+
+            let encodedURLPath = templateFilename.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
+            let templateURL = URL(string: encodedURLPath, relativeTo: templateBaseURL)!.standardizedFileURL
             let templateAbsoluteString = templateURL.absoluteString
             
             // Make sure partial relative paths can not escape repository root

--- a/Tests/Public/TemplateRepositoryTests/TemplateRepositoryFileSystemTests/TemplateRepositoryFileSystemTests/contains whitespace.mustache
+++ b/Tests/Public/TemplateRepositoryTests/TemplateRepositoryFileSystemTests/TemplateRepositoryFileSystemTests/contains whitespace.mustache
@@ -1,0 +1,1 @@
+success

--- a/Tests/Public/TemplateRepositoryTests/TemplateRepositoryFileSystemTests/TemplateRepositoryFileSystemTests/contains whitespace/contains whitespace.mustache
+++ b/Tests/Public/TemplateRepositoryTests/TemplateRepositoryFileSystemTests/TemplateRepositoryFileSystemTests/contains whitespace/contains whitespace.mustache
@@ -1,0 +1,1 @@
+success

--- a/Tests/Public/TemplateRepositoryTests/TemplateRepositoryFileSystemTests/TemplateRepositoryPathTests.swift
+++ b/Tests/Public/TemplateRepositoryTests/TemplateRepositoryFileSystemTests/TemplateRepositoryPathTests.swift
@@ -127,4 +127,22 @@ class TemplateRepositoryPathTests: XCTestCase {
             XCTFail("Expected MustacheError")
         }
     }
+
+    func testFileNameContainsWhitespace() {
+        let testBundle = Bundle(for: type(of: self))
+        let directoryPath = testBundle.path(forResource: "TemplateRepositoryFileSystemTests", ofType: nil)!
+        let repo = TemplateRepository(directoryPath: directoryPath)
+        let template = try! repo.template(named: "contains whitespace")
+        let rendering = try! template.render()
+        XCTAssertEqual(rendering, "success\n")
+    }
+
+    func testFileAndDictonaryNameContainsWhitespace() {
+        let testBundle = Bundle(for: type(of: self))
+        let directoryPath = testBundle.path(forResource: "TemplateRepositoryFileSystemTests/contains whitespace", ofType: nil)!
+        let repo = TemplateRepository(directoryPath: directoryPath)
+        let template = try! repo.template(named: "contains whitespace")
+        let rendering = try! template.render()
+        XCTAssertEqual(rendering, "success\n")
+    }
 }

--- a/Tests/Public/TemplateRepositoryTests/TemplateRepositoryFileSystemTests/TemplateRepositoryURLTests.swift
+++ b/Tests/Public/TemplateRepositoryTests/TemplateRepositoryFileSystemTests/TemplateRepositoryURLTests.swift
@@ -127,4 +127,22 @@ class TemplateRepositoryURLTests: XCTestCase {
             XCTFail("Expected MustacheError")
         }
     }
+
+    func testFileNameContainsWhitespace() {
+        let testBundle = Bundle(for: type(of: self))
+        let directoryPath = testBundle.url(forResource: "TemplateRepositoryFileSystemTests", withExtension: nil)!
+        let repo = TemplateRepository(baseURL: directoryPath)
+        let template = try! repo.template(named: "contains whitespace")
+        let rendering = try! template.render()
+        XCTAssertEqual(rendering, "success\n")
+    }
+
+    func testFileAndDictionaryNameContainsWhitespace() {
+        let testBundle = Bundle(for: type(of: self))
+        let directoryPath = testBundle.url(forResource: "TemplateRepositoryFileSystemTests/contains whitespace", withExtension: nil)!
+        let repo = TemplateRepository(baseURL: directoryPath)
+        let template = try! repo.template(named: "contains whitespace")
+        let rendering = try! template.render()
+        XCTAssertEqual(rendering, "success\n")
+    }
 }


### PR DESCRIPTION
fixes #72 and ref: #50

Mustache.swift calls `URL(string:)` when constructing file path. But it causes some crashes when the file name contains white space. 

Generally, `URL(fileURLWithPath:)` is used to solve such problems, but this API is not available in Mustache.swift because it supports iOS 9+. Therefore, encode the URL path to be added beforehand to work around the problem.