### PR TITLE
Fix warning in `EachFilter` in Xcode 14.3

### DIFF
--- a/Sources/EachFilter.swift
+++ b/Sources/EachFilter.swift
@@ -43,7 +43,7 @@ let EachFilter = Filter { (box: MustacheBox) -> Any? in
     // (NSDictionary, [String: Int], [String: CustomObject], etc.
     if let dictionary = box.dictionaryValue {
         let count = dictionary.count
-        let customRenderFunctions = dictionary.enumerated().map { (index: Int, element: (key: String, box: MustacheBox)) -> Any? in
+        let customRenderFunctions = dictionary.enumerated().map { (index: Int, element: (key: String, value: MustacheBox)) -> Any? in
             let customRenderFunction: RenderFunction = { info in
                 // Push positional keys in the context stack and then perform
                 // a regular rendering.
@@ -57,7 +57,7 @@ let EachFilter = Filter { (box: MustacheBox) -> Any? in
                 
                 var info = info
                 info.context = info.context.extendedContext(position)
-                return try element.box.render(info)
+                return try element.value.render(info)
             }
             return customRenderFunction
         }


### PR DESCRIPTION
Fix the following warning in Xcode 14.3 (14E222b):

```
Sources/EachFilter.swift:46:65: Tuple conversion from '(key: String, value: MustacheBox)' to '(key: String, box: MustacheBox)' mismatches labels
```

<img width="1542" alt="Screenshot 2023-04-05 at 7 54 29 AM" src="https://user-images.githubusercontent.com/6780049/230119900-ff663e71-4b7e-4abd-997d-c5ae35d23231.png">

[Related changes in apple/swift](https://github.com/apple/swift/commit/4aaec657807ded8d03dbcc64d5962429c1f96983#diff-98b97dbd606780be0ea9acbdb793ab3bafbe4a22fc047fed6bca817e6fbddaa7):

>    // If we had a label mismatch, emit a warning. This is something we
      // shouldn't permit, as it's more permissive than what a conversion would
      // allow. Ideally we'd turn this into an error in Swift 6 mode.



