### PR TITLE
Fix Concurrency issues originating in Swift6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,9 +21,7 @@ let package = Package(
             dependencies: ["GRMustacheKeyAccess"],
             path: "Sources",
             swiftSettings: [
-                .define("OBJC"),
-                .unsafeFlags(["-Xfrontend", "-strict-concurrency=complete"]),
-                .unsafeFlags(["-Xfrontend", "-warnings-as-errors"])
+                .define("OBJC")
             ]
         ),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,9 @@ let package = Package(
             dependencies: ["GRMustacheKeyAccess"],
             path: "Sources",
             swiftSettings: [
-                .define("OBJC")
+                .define("OBJC"),
+                .unsafeFlags(["-Xfrontend", "-strict-concurrency=complete"]),
+                .unsafeFlags(["-Xfrontend", "-warnings-as-errors"])
             ]
         ),
         .target(

--- a/Sources/Box.swift
+++ b/Sources/Box.swift
@@ -202,7 +202,7 @@ public protocol MustacheBoxable {
 /// - returns: A MustacheBox.
 public func Box(_ value: Any?) -> MustacheBox {
     guard let value = value else {
-        return EmptyBox
+        return .empty
     }
     
     switch value {
@@ -226,7 +226,7 @@ public func Box(_ value: Any?) -> MustacheBox {
         return MustacheBox(keyedSubscript: f)
     default:
         NSLog("%@", "Mustache warning: \(String(reflecting: value)) of type \(type(of: value)) is not MustacheBoxable, Array, Set, Dictionary, and is discarded.")
-        return EmptyBox
+        return .empty
     }
 }
 
@@ -339,18 +339,18 @@ extension MustacheBox {
                     if let first = array.first {
                         return Box(first)
                     } else {
-                        return EmptyBox
+                        return MustacheBox.empty
                     }
                 case "last":    // C.Index: BidirectionalIndexType
                     if let last = array.last {
                         return Box(last)
                     } else {
-                        return EmptyBox
+                        return MustacheBox.empty
                     }
                 case "count":   // C.IndexDistance == Int
                     return Box(array.count)
                 default:
-                    return EmptyBox
+                    return MustacheBox.empty
                 }
             },
             render: { (info: RenderingInfo) in
@@ -376,12 +376,12 @@ extension MustacheBox {
                     if let first = set.first {
                         return Box(first)
                     } else {
-                        return EmptyBox
+                        return MustacheBox.empty
                     }
                 case "count":   // C.IndexDistance == Int
                     return Box(set.count)
                 default:
-                    return EmptyBox
+                    return MustacheBox.empty
                 }
             },
             render: { (info: RenderingInfo) in
@@ -415,10 +415,14 @@ extension MustacheBox {
                 if let value = dictionary[key] {
                     return Box(value)
                 } else {
-                    return EmptyBox
+                    return MustacheBox.empty
                 }
         })
     }
 }
 
-let EmptyBox = MustacheBox()
+extension MustacheBox {
+    static var empty: MustacheBox {
+        MustacheBox()
+    }
+}

--- a/Sources/Common.swift
+++ b/Sources/Common.swift
@@ -48,7 +48,7 @@ public enum ContentType {
 public struct MustacheError : Error {
     
     /// MustacheError types
-    public enum Kind : Int {
+    public enum Kind : Int, Sendable {
         case templateNotFound
         case parseError
         case renderError

--- a/Sources/Configuration.swift
+++ b/Sources/Configuration.swift
@@ -75,7 +75,13 @@
 /// Templates can also be configured individually. See the documentation of each
 /// Configuration method for more details.
 public struct Configuration {
-    
+
+    /// The default configuration that is used unless specified otherwise by a
+    /// TemplateRepository.
+    public static var `default`: Configuration {
+        Configuration()
+    }
+
     // =========================================================================
     // MARK: - Factory Configuration
     
@@ -296,11 +302,3 @@ public struct Configuration {
     /// Delimiter tag": `{{=[[ ]]=}}` changes delimiters to `[[` and `]]`.
     public var tagDelimiterPair: TagDelimiterPair
 }
-
-
-// =============================================================================
-// MARK: - Default Configuration
-
-/// The default configuration that is used unless specified otherwise by a
-/// TemplateRepository.
-nonisolated(unsafe) public var DefaultConfiguration = Configuration()

--- a/Sources/Configuration.swift
+++ b/Sources/Configuration.swift
@@ -303,4 +303,4 @@ public struct Configuration {
 
 /// The default configuration that is used unless specified otherwise by a
 /// TemplateRepository.
-public var DefaultConfiguration = Configuration()
+nonisolated(unsafe) public var DefaultConfiguration = Configuration()

--- a/Sources/Context.swift
+++ b/Sources/Context.swift
@@ -111,7 +111,7 @@ final public class Context {
     public var topBox: MustacheBox {
         switch type {
         case .root:
-            return EmptyBox
+            return .empty
         case .box(box: let box, parent: _):
             return box
         case .partialOverride(partialOverride: _, parent: let parent):
@@ -151,7 +151,7 @@ final public class Context {
         
         switch type {
         case .root:
-            return EmptyBox
+            return .empty
         case .box(box: let box, parent: let parent):
             let innerBox = box.mustacheBox(forKey: key)
             if innerBox.isEmpty {

--- a/Sources/CoreFunctions.swift
+++ b/Sources/CoreFunctions.swift
@@ -470,8 +470,9 @@ public typealias RenderFunction = (_ info: RenderingInfo) throws -> Rendering
 ///     let rendering = try! template.render(data)
 /// 
 /// - parameter lambda: A `String -> String` function.
+/// - parameter configuration: The configuration for rendering. If the configuration is not specified, `Configuration.default` is used.
 /// - returns: A RenderFunction.
-public func Lambda(_ lambda: @escaping (String) -> String) -> RenderFunction {
+public func Lambda(_ lambda: @escaping (String) -> String, configuration: Configuration = .default) -> RenderFunction {
     return { (info: RenderingInfo) in
         switch info.tag.type {
         case .variable:
@@ -483,7 +484,7 @@ public func Lambda(_ lambda: @escaping (String) -> String) -> RenderFunction {
             // https://github.com/mustache/spec/blob/83b0721610a4e11832e83df19c73ace3289972b9/specs/%7Elambdas.yml#L117
             // > Lambdas used for sections should parse with the current delimiters
             
-            let templateRepository = TemplateRepository()
+            let templateRepository = TemplateRepository(configuration: configuration)
             templateRepository.configuration.tagDelimiterPair = info.tag.tagDelimiterPair
             
             let templateString = lambda(info.tag.innerTemplateString)
@@ -585,8 +586,9 @@ public func Lambda(_ lambda: @escaping (String) -> String) -> RenderFunction {
 ///     let rendering = try! template.render(data)
 /// 
 /// - parameter lambda: A `() -> String` function.
+/// - parameter configuration: The configuration for rendering. If the configuration is not specified, `Configuration.default` is used.
 /// - returns: A RenderFunction.
-public func Lambda(_ lambda: @escaping () -> String) -> RenderFunction {
+public func Lambda(_ lambda: @escaping () -> String, configuration: Configuration = .default) -> RenderFunction {
     return { (info: RenderingInfo) in
         switch info.tag.type {
         case .variable:
@@ -597,7 +599,7 @@ public func Lambda(_ lambda: @escaping () -> String) -> RenderFunction {
             //
             // Let's render a text template:
             
-            let templateRepository = TemplateRepository()
+            let templateRepository = TemplateRepository(configuration: configuration)
             templateRepository.configuration.contentType = .text
             
             let templateString = lambda()
@@ -658,7 +660,7 @@ public func Lambda(_ lambda: @escaping () -> String) -> RenderFunction {
             // {{# lambda }}...{{/ lambda }}
             //
             // Behave as a true object, and render the section.
-            let context = info.context.extendedContext(Lambda(lambda))
+            let context = info.context.extendedContext(Lambda(lambda, configuration: configuration))
             return try info.tag.render(context)
         }
     }

--- a/Sources/EachFilter.swift
+++ b/Sources/EachFilter.swift
@@ -23,80 +23,82 @@
 
 import Foundation
 
-let EachFilter = Filter { (box: MustacheBox) -> Any? in
-    
-    // {{# each(nothing) }}...{{/ }}
-    if box.isEmpty {
-        return box
-    }
-    
-    // {{# each(dictionary) }}...{{/ }}
-    //
-    //     // Renders "firstName: Charles, lastName: Bronson."
-    //     let dictionary = ["firstName": "Charles", "lastName": "Bronson"]
-    //     let template = try! Template(string: "{{# each(dictionary) }}{{ @key }}: {{ . }}{{^ @last }}, {{/ @last }}{{/ each(dictionary) }}.")
-    //     template.register(StandardLibrary.each, forKey: "each")
-    //     try! template.render(["dictionary": dictionary])
-    //
-    // The dictionaryValue box property makes sure to return a
-    // [String: MustacheBox] whatever the boxed dictionary-like value
-    // (NSDictionary, [String: Int], [String: CustomObject], etc.
-    if let dictionary = box.dictionaryValue {
-        let count = dictionary.count
-        let customRenderFunctions = dictionary.enumerated().map { (index: Int, element: (key: String, value: MustacheBox)) -> Any? in
-            let customRenderFunction: RenderFunction = { info in
-                // Push positional keys in the context stack and then perform
-                // a regular rendering.
-                var position: [String: Any] = [:]
-                position["@index"] = index
-                position["@indexPlusOne"] = index + 1
-                position["@indexIsEven"] = (index % 2 == 0)
-                position["@first"] = (index == 0)
-                position["@last"] = ((index == count - 1))
-                position["@key"] = element.key
-                
-                var info = info
-                info.context = info.context.extendedContext(position)
-                return try element.value.render(info)
-            }
-            return customRenderFunction
+func EachFilter() -> FilterFunction {
+    Filter { (box: MustacheBox) -> Any? in
+
+        // {{# each(nothing) }}...{{/ }}
+        if box.isEmpty {
+            return box
         }
-        return customRenderFunctions
-    }
-    
-    
-    // {{# each(array) }}...{{/ }}
-    //
-    //     // Renders "1: bread, 2: ham, 3: butter"
-    //     let array = ["bread", "ham", "butter"]
-    //     let template = try! Template(string: "{{# each(array) }}{{ @indexPlusOne }}: {{ . }}{{^ @last }}, {{/ @last }}{{/ each(array) }}.")
-    //     template.register(StandardLibrary.each, forKey: "each")
-    //     try! template.render(["array": array])
-    //
-    // The arrayValue box property makes sure to return a [MustacheBox] whatever
-    // the boxed collection: NSArray, NSSet, [String], [CustomObject], etc.
-    if let boxes = box.arrayValue {
-        let count = boxes.count
-        let customRenderFunctions = boxes.enumerated().map { (index: Int, box: MustacheBox) -> Any? in
-            let customRenderFunction: RenderFunction = { info in
-                // Push positional keys in the context stack and then perform
-                // a regular rendering.
-                var position: [String: Any] = [:]
-                position["@index"] = index
-                position["@indexPlusOne"] = index + 1
-                position["@indexIsEven"] = (index % 2 == 0)
-                position["@first"] = (index == 0)
-                position["@last"] = ((index == count - 1))
-                
-                var info = info
-                info.context = info.context.extendedContext(position)
-                return try box.render(info)
+
+        // {{# each(dictionary) }}...{{/ }}
+        //
+        //     // Renders "firstName: Charles, lastName: Bronson."
+        //     let dictionary = ["firstName": "Charles", "lastName": "Bronson"]
+        //     let template = try! Template(string: "{{# each(dictionary) }}{{ @key }}: {{ . }}{{^ @last }}, {{/ @last }}{{/ each(dictionary) }}.")
+        //     template.register(StandardLibrary.each, forKey: "each")
+        //     try! template.render(["dictionary": dictionary])
+        //
+        // The dictionaryValue box property makes sure to return a
+        // [String: MustacheBox] whatever the boxed dictionary-like value
+        // (NSDictionary, [String: Int], [String: CustomObject], etc.
+        if let dictionary = box.dictionaryValue {
+            let count = dictionary.count
+            let customRenderFunctions = dictionary.enumerated().map { (index: Int, element: (key: String, value: MustacheBox)) -> Any? in
+                let customRenderFunction: RenderFunction = { info in
+                    // Push positional keys in the context stack and then perform
+                    // a regular rendering.
+                    var position: [String: Any] = [:]
+                    position["@index"] = index
+                    position["@indexPlusOne"] = index + 1
+                    position["@indexIsEven"] = (index % 2 == 0)
+                    position["@first"] = (index == 0)
+                    position["@last"] = ((index == count - 1))
+                    position["@key"] = element.key
+
+                    var info = info
+                    info.context = info.context.extendedContext(position)
+                    return try element.value.render(info)
+                }
+                return customRenderFunction
             }
-            return customRenderFunction
+            return customRenderFunctions
         }
-        return customRenderFunctions
+
+
+        // {{# each(array) }}...{{/ }}
+        //
+        //     // Renders "1: bread, 2: ham, 3: butter"
+        //     let array = ["bread", "ham", "butter"]
+        //     let template = try! Template(string: "{{# each(array) }}{{ @indexPlusOne }}: {{ . }}{{^ @last }}, {{/ @last }}{{/ each(array) }}.")
+        //     template.register(StandardLibrary.each, forKey: "each")
+        //     try! template.render(["array": array])
+        //
+        // The arrayValue box property makes sure to return a [MustacheBox] whatever
+        // the boxed collection: NSArray, NSSet, [String], [CustomObject], etc.
+        if let boxes = box.arrayValue {
+            let count = boxes.count
+            let customRenderFunctions = boxes.enumerated().map { (index: Int, box: MustacheBox) -> Any? in
+                let customRenderFunction: RenderFunction = { info in
+                    // Push positional keys in the context stack and then perform
+                    // a regular rendering.
+                    var position: [String: Any] = [:]
+                    position["@index"] = index
+                    position["@indexPlusOne"] = index + 1
+                    position["@indexIsEven"] = (index % 2 == 0)
+                    position["@first"] = (index == 0)
+                    position["@last"] = ((index == count - 1))
+
+                    var info = info
+                    info.context = info.context.extendedContext(position)
+                    return try box.render(info)
+                }
+                return customRenderFunction
+            }
+            return customRenderFunctions
+        }
+
+        // Non-iterable value
+        throw MustacheError(kind: .renderError, message: "Non-enumerable argument in each filter: \(box.value.map { String(reflecting: $0) } ?? "nil")")
     }
-    
-    // Non-iterable value
-    throw MustacheError(kind: .renderError, message: "Non-enumerable argument in each filter: \(box.value.map { String(reflecting: $0) } ?? "nil")")
 }

--- a/Sources/ExpressionGenerator.swift
+++ b/Sources/ExpressionGenerator.swift
@@ -33,7 +33,7 @@ final class ExpressionGenerator {
     let configuration: Configuration
     
     init(configuration: Configuration? = nil) {
-        self.configuration = configuration ?? DefaultConfiguration
+        self.configuration = configuration ?? .default
     }
     
     func stringFromExpression(_ expression: Expression) -> String {

--- a/Sources/Fixit-1.1.0.swift
+++ b/Sources/Fixit-1.1.0.swift
@@ -22,7 +22,7 @@
 
 
 @available(*, unavailable, message:"Use nil instead.")
-public func Box() -> MustacheBox { return EmptyBox }
+public func Box() -> MustacheBox { return .empty }
 
 extension Template {
     @available(*, unavailable, renamed:"register(_:forKey:)")
@@ -31,16 +31,16 @@ extension Template {
 
 extension Context {
     @available(*, unavailable, renamed:"mustacheBox(forKey:)")
-    public func mustacheBoxForKey(_ key: String) -> MustacheBox { return EmptyBox }
-    
+    public func mustacheBoxForKey(_ key: String) -> MustacheBox { return .empty }
+
     @available(*, unavailable, renamed:"mustacheBox(forExpression:)")
-    public func mustacheBoxForExpression(_ string: String) throws -> MustacheBox { return EmptyBox }
-    
+    public func mustacheBoxForExpression(_ string: String) throws -> MustacheBox { return .empty }
+
     @available(*, unavailable, renamed:"extendedContext(withRegisteredValue:forKey:)")
     func contextWithRegisteredKey(_ key: String, box: MustacheBox) -> Context { return self }
 }
 
 extension MustacheBox {
     @nonobjc @available(*, unavailable, renamed:"mustacheBox(forKey:)")
-    public func mustacheBoxForKey(_ key: String) -> MustacheBox { return EmptyBox }
+    public func mustacheBoxForKey(_ key: String) -> MustacheBox { return .empty }
 }

--- a/Sources/MustacheBox.swift
+++ b/Sources/MustacheBox.swift
@@ -123,7 +123,7 @@ final public class MustacheBox : NSObject {
     /// - returns: The MustacheBox for *key*.
     public func mustacheBox(forKey key: String) -> MustacheBox {
         guard let keyedSubscript = keyedSubscript else {
-            return EmptyBox
+            return MustacheBox.empty
         }
         return Box(keyedSubscript(key))
     }

--- a/Sources/StandardLibrary.swift
+++ b/Sources/StandardLibrary.swift
@@ -160,8 +160,10 @@ public struct StandardLibrary {
     /// 
     ///     let template = ...
     ///     template.register(StandardLibrary.each, forKey: "each")
-    public static let each = EachFilter
-    
+    public static var each: FilterFunction {
+        EachFilter()
+    }
+
     /// The zip filter iterates several lists all at once. On each step, one object
     /// from each input list enters the rendering context, and makes its own keys
     /// available for rendering.
@@ -205,5 +207,7 @@ public struct StandardLibrary {
     /// 
     ///     let template = ...
     ///     template.register(StandardLibrary.zip, forKey: "zip")
-    public static let zip = ZipFilter
+    public static var zip: FilterFunction {
+        ZipFilter()
+    }
 }

--- a/Sources/StandardLibrary.swift
+++ b/Sources/StandardLibrary.swift
@@ -50,8 +50,10 @@ public struct StandardLibrary {
     /// 
     ///     let template = ...
     ///     template.register(StandardLibrary.HTMLEscape, forKey: "HTMLEscape")
-    public static let HTMLEscape: MustacheBoxable = HTMLEscapeHelper()
-    
+    public static var HTMLEscape: MustacheBoxable {
+        HTMLEscapeHelper()
+    }
+
     /// As a filter, `URLEscape` returns its argument, percent-escaped.
     /// 
     ///     <a href="http://google.com?q={{ URLEscape(query) }}">...</a>
@@ -74,8 +76,10 @@ public struct StandardLibrary {
     /// 
     ///     let template = ...
     ///     template.register(StandardLibrary.URLEscape, forKey: "URLEscape")
-    public static let URLEscape: MustacheBoxable = URLEscapeHelper()
-    
+    public static var URLEscape: MustacheBoxable {
+        URLEscapeHelper()
+    }
+
     /// As a filter, `javascriptEscape` outputs a Javascript and JSON-savvy string:
     /// 
     ///     <script type="text/javascript">
@@ -106,8 +110,10 @@ public struct StandardLibrary {
     /// 
     ///     let template = ...
     ///     template.register(StandardLibrary.javascriptEscape, forKey: "javascriptEscape")
-    public static let javascriptEscape: MustacheBoxable = JavascriptEscapeHelper()
-    
+    public static var javascriptEscape: MustacheBoxable {
+        JavascriptEscapeHelper()
+    }
+
     /// Iteration is natural to Mustache templates:
     /// `{{# users }}{{ name }}, {{/ users }}` renders "Alice, Bob, etc." when the
     /// `users` key is given a list of users.

--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -32,9 +32,10 @@ final public class Template {
     /// Creates a template from a template string.
     /// 
     /// - parameter string: The template string.
+    /// - parameter configuration: The configuration for rendering. If the configuration is not specified, `Configuration.default` is used.
     /// - throws: MustacheError
-    public convenience init(string: String) throws {
-        let repository = TemplateRepository()
+    public convenience init(string: String, configuration: Configuration = .default) throws {
+        let repository = TemplateRepository(configuration: configuration)
         let templateAST = try repository.templateAST(string: string)
         self.init(repository: repository, templateAST: templateAST, baseContext: repository.configuration.baseContext)
     }
@@ -49,13 +50,14 @@ final public class Template {
     /// 
     /// - parameter path: The path to the template file.
     /// - parameter encoding: The encoding of the template file.
+    /// - parameter configuration: The configuration for rendering. If the configuration is not specified, `Configuration.default` is used.
     /// - throws: MustacheError
-    public convenience init(path: String, encoding: String.Encoding = String.Encoding.utf8) throws {
+    public convenience init(path: String, encoding: String.Encoding = String.Encoding.utf8, configuration: Configuration = .default) throws {
         let nsPath = path as NSString
         let directoryPath = nsPath.deletingLastPathComponent
         let templateExtension = nsPath.pathExtension
         let templateName = (nsPath.lastPathComponent as NSString).deletingPathExtension
-        let repository = TemplateRepository(directoryPath: directoryPath, templateExtension: templateExtension, encoding: encoding)
+        let repository = TemplateRepository(directoryPath: directoryPath, templateExtension: templateExtension, encoding: encoding, configuration: configuration)
         let templateAST = try repository.templateAST(named: templateName)
         self.init(repository: repository, templateAST: templateAST, baseContext: repository.configuration.baseContext)
     }
@@ -70,12 +72,13 @@ final public class Template {
     /// 
     /// - parameter URL: The URL of the template.
     /// - parameter encoding: The encoding of the template resource.
+    /// - parameter configuration: The configuration for rendering. If the configuration is not specified, `Configuration.default` is used.
     /// - throws: MustacheError
-    public convenience init(URL: Foundation.URL, encoding: String.Encoding = String.Encoding.utf8) throws {
+    public convenience init(URL: Foundation.URL, encoding: String.Encoding = String.Encoding.utf8, configuration: Configuration = .default) throws {
         let baseURL = URL.deletingLastPathComponent()
         let templateExtension = URL.pathExtension
         let templateName = (URL.lastPathComponent as NSString).deletingPathExtension
-        let repository = TemplateRepository(baseURL: baseURL, templateExtension: templateExtension, encoding: encoding)
+        let repository = TemplateRepository(baseURL: baseURL, templateExtension: templateExtension, encoding: encoding, configuration: configuration)
         let templateAST = try repository.templateAST(named: templateName)
         self.init(repository: repository, templateAST: templateAST, baseContext: repository.configuration.baseContext)
     }
@@ -95,9 +98,10 @@ final public class Template {
     ///   the extension is assumed not to exist and the template file should
     ///   exactly match name.
     /// - parameter encoding: The encoding of template resource.
+    /// - parameter configuration: The configuration for rendering. If the configuration is not specified, `Configuration.default` is used.
     /// - throws: MustacheError
-    public convenience init(named name: String, bundle: Bundle? = nil, templateExtension: String? = "mustache", encoding: String.Encoding = String.Encoding.utf8) throws {
-        let repository = TemplateRepository(bundle: bundle, templateExtension: templateExtension, encoding: encoding)
+    public convenience init(named name: String, bundle: Bundle? = nil, templateExtension: String? = "mustache", encoding: String.Encoding = String.Encoding.utf8, configuration: Configuration = .default) throws {
+        let repository = TemplateRepository(bundle: bundle, templateExtension: templateExtension, encoding: encoding, configuration: configuration)
         let templateAST = try repository.templateAST(named: name)
         self.init(repository: repository, templateAST: templateAST, baseContext: repository.configuration.baseContext)
     }

--- a/Sources/TemplateGenerator.swift
+++ b/Sources/TemplateGenerator.swift
@@ -41,7 +41,7 @@ final class TemplateGenerator {
     let configuration: Configuration
     
     init(configuration: Configuration? = nil) {
-        self.configuration = configuration ?? DefaultConfiguration
+        self.configuration = configuration ?? .default
     }
     
     func stringFromTemplateAST(_ templateAST: TemplateAST) -> String {

--- a/Sources/TemplateRepository.swift
+++ b/Sources/TemplateRepository.swift
@@ -106,8 +106,8 @@ final public class TemplateRepository {
     /// 
     ///     let repository = TemplateRepository()
     ///     let template = try! repository.template(string: "Hello {{name}}")
-    public init(dataSource: TemplateRepositoryDataSource? = nil) {
-        configuration = DefaultConfiguration
+    public init(dataSource: TemplateRepositoryDataSource? = nil, configuration: Configuration = .default) {
+        self.configuration = configuration
         templateASTCache = [:]
         self.dataSource = dataSource
     }
@@ -123,8 +123,9 @@ final public class TemplateRepository {
     /// 
     /// - parameter templates: A dictionary whose keys are template names and
     ///   values template strings.
-    convenience public init(templates: [String: String]) {
-        self.init(dataSource: DictionaryDataSource(templates: templates))
+    /// - parameter configuration: The configuration for rendering. If the configuration is not specified, `Configuration.default` is used.
+    convenience public init(templates: [String: String], configuration: Configuration = .default) {
+        self.init(dataSource: DictionaryDataSource(templates: templates), configuration: configuration)
     }
     
     /// Creates a TemplateRepository that loads templates from a directory.
@@ -160,8 +161,9 @@ final public class TemplateRepository {
     ///   extension is "mustache".
     /// - parameter encoding: The encoding of template files. Default encoding
     ///   is UTF-8.
-    convenience public init(directoryPath: String, templateExtension: String? = "mustache", encoding: String.Encoding = String.Encoding.utf8) {
-        self.init(dataSource: URLDataSource(baseURL: URL(fileURLWithPath: directoryPath, isDirectory: true), templateExtension: templateExtension, encoding: encoding))
+    /// - parameter configuration: The configuration for rendering. If the configuration is not specified, `Configuration.default` is used.
+    convenience public init(directoryPath: String, templateExtension: String? = "mustache", encoding: String.Encoding = String.Encoding.utf8, configuration: Configuration = .default) {
+        self.init(dataSource: URLDataSource(baseURL: URL(fileURLWithPath: directoryPath, isDirectory: true), templateExtension: templateExtension, encoding: encoding), configuration: configuration)
     }
     
     /// Creates a TemplateRepository that loads templates from a URL.
@@ -197,8 +199,9 @@ final public class TemplateRepository {
     ///   Default extension is "mustache".
     /// - parameter encoding: The encoding of template resources. Default
     ///   encoding is UTF-8.
-    convenience public init(baseURL: URL, templateExtension: String? = "mustache", encoding: String.Encoding = String.Encoding.utf8) {
-        self.init(dataSource: URLDataSource(baseURL: baseURL, templateExtension: templateExtension, encoding: encoding))
+    /// - parameter configuration: The configuration for rendering. If the configuration is not specified, `Configuration.default` is used.
+    convenience public init(baseURL: URL, templateExtension: String? = "mustache", encoding: String.Encoding = String.Encoding.utf8, configuration: Configuration = .default) {
+        self.init(dataSource: URLDataSource(baseURL: baseURL, templateExtension: templateExtension, encoding: encoding), configuration: configuration)
     }
     
     /// Creates a TemplateRepository that loads templates stored as resources in
@@ -215,8 +218,9 @@ final public class TemplateRepository {
     ///   Default extension is "mustache".
     /// - parameter encoding: The encoding of template resources. Default
     ///   encoding is UTF-8.
-    convenience public init(bundle: Bundle?, templateExtension: String? = "mustache", encoding: String.Encoding = String.Encoding.utf8) {
-        self.init(dataSource: BundleDataSource(bundle: bundle ?? Bundle.main, templateExtension: templateExtension, encoding: encoding))
+    /// - parameter configuration: The configuration for rendering. If the configuration is not specified, `Configuration.default` is used.
+    convenience public init(bundle: Bundle?, templateExtension: String? = "mustache", encoding: String.Encoding = String.Encoding.utf8, configuration: Configuration = .default) {
+        self.init(dataSource: BundleDataSource(bundle: bundle ?? Bundle.main, templateExtension: templateExtension, encoding: encoding), configuration: configuration)
     }
     
     

--- a/Tests/Public/ConfigurationTests/ConfigurationBaseContextTests.swift
+++ b/Tests/Public/ConfigurationTests/ConfigurationBaseContextTests.swift
@@ -25,33 +25,31 @@ import XCTest
 import Mustache
 
 class ConfigurationBaseContextTests: XCTestCase {
-    
-    override func tearDown() {
-        super.tearDown()
-        DefaultConfiguration = Configuration()
-    }
-    
+
     func testDefaultConfigurationCustomBaseContext() {
-        DefaultConfiguration.baseContext = Context(["foo": "success"])
-        
-        let template = try! Template(string: "{{foo}}")
+        var configuration = Configuration.default
+        configuration.baseContext = Context(["foo": "success"])
+
+        let template = try! Template(string: "{{foo}}", configuration: configuration)
         let rendering = try! template.render()
         XCTAssertEqual(rendering, "success")
     }
     
     func testTemplateBaseContextOverridesDefaultConfigurationBaseContext() {
-        DefaultConfiguration.baseContext = Context(["foo": "failure"])
-        
-        let template = try! Template(string: "{{foo}}")
+        var configuration = Configuration.default
+        configuration.baseContext = Context(["foo": "failure"])
+
+        let template = try! Template(string: "{{foo}}", configuration: configuration)
         template.baseContext = Context(["foo": "success"])
         let rendering = try! template.render()
         XCTAssertEqual(rendering, "success")
     }
     
     func testDefaultRepositoryConfigurationHasDefaultConfigurationBaseContext() {
-        DefaultConfiguration.baseContext = Context(["foo": "success"])
-        
-        let repository = TemplateRepository()
+        var configuration = Configuration.default
+        configuration.baseContext = Context(["foo": "success"])
+
+        let repository = TemplateRepository(configuration: configuration)
         let template = try! repository.template(string: "{{foo}}")
         let rendering = try! template.render()
         XCTAssertEqual(rendering, "success")
@@ -79,8 +77,6 @@ class ConfigurationBaseContextTests: XCTestCase {
     }
     
     func testRepositoryConfigurationBaseContextOverridesDefaultConfigurationBaseContextWhenSettingTheWholeConfiguration() {
-        DefaultConfiguration.baseContext = Context(["foo": "failure"])
-        
         var configuration = Configuration()
         configuration.baseContext = Context(["foo": "success"])
         
@@ -93,8 +89,6 @@ class ConfigurationBaseContextTests: XCTestCase {
     }
     
     func testRepositoryConfigurationBaseContextOverridesDefaultConfigurationBaseContextWhenUpdatingRepositoryConfiguration() {
-        DefaultConfiguration.baseContext = Context(["foo": "failure"])
-        
         let repository = TemplateRepository()
         repository.configuration.baseContext = Context(["foo": "success"])
         
@@ -133,8 +127,10 @@ class ConfigurationBaseContextTests: XCTestCase {
         
         var rendering = try! repository.template(string: "{{^foo}}success{{/foo}}").render()
         XCTAssertEqual(rendering, "success")
-        
-        DefaultConfiguration.baseContext = Context(["foo": "failure"])
+
+        var configuration = Configuration.default
+        configuration.baseContext = Context(["foo": "failure"])
+        repository.configuration = configuration
         rendering = try! repository.template(string: "{{^foo}}success{{/foo}}").render()
         XCTAssertEqual(rendering, "success")
     }

--- a/Tests/Public/ConfigurationTests/ConfigurationContentTypeTests.swift
+++ b/Tests/Public/ConfigurationTests/ConfigurationContentTypeTests.swift
@@ -26,32 +26,27 @@ import Mustache
 
 class ConfigurationContentTypeTests: XCTestCase {
     
-    override func tearDown() {
-        super.tearDown()
-        DefaultConfiguration = Configuration()
-    }
-    
-    
     func testFactoryConfigurationHasHTMLContentTypeRegardlessOfDefaultConfiguration() {
-        DefaultConfiguration.contentType = .html
         var configuration = Configuration()
+        configuration.contentType = .html
         XCTAssertEqual(configuration.contentType, ContentType.html)
-        
-        DefaultConfiguration.contentType = .text
-        configuration = Configuration()
-        XCTAssertEqual(configuration.contentType, ContentType.html)
+
+        configuration.contentType = .text
+        XCTAssertEqual(Configuration.default.contentType, ContentType.html)
     }
     
     func testDefaultConfigurationContentTypeHTMLHasTemplateRenderEscapedInput() {
-        DefaultConfiguration.contentType = .html
-        let template = try! Template(string: "{{.}}")
+        var configuration = Configuration.default
+        configuration.contentType = .html
+        let template = try! Template(string: "{{.}}", configuration: configuration)
         let rendering = try! template.render("&")
         XCTAssertEqual(rendering, "&amp;")
     }
 
     func testDefaultConfigurationContentTypeTextLHasTemplateRenderUnescapedInput() {
-        DefaultConfiguration.contentType = .text
-        let template = try! Template(string: "{{.}}")
+        var configuration = Configuration.default
+        configuration.contentType = .text
+        let template = try! Template(string: "{{.}}", configuration: configuration)
         let rendering = try! template.render("&")
         XCTAssertEqual(rendering, "&")
     }
@@ -63,10 +58,10 @@ class ConfigurationContentTypeTests: XCTestCase {
         // There is no public way to build a RenderingInfo.
         //
         // Thus we'll use a rendering object that will provide us with one:
-        
-        DefaultConfiguration.contentType = .html
-        
-        let testedTemplate = try! Template(string: "")
+        var configuration = Configuration.default
+        configuration.contentType = .html
+
+        let testedTemplate = try! Template(string: "", configuration: configuration)
         var testedContentType: ContentType?
         let render = { (info: RenderingInfo) -> Rendering in
             let rendering = try testedTemplate.render(info.context)
@@ -86,10 +81,10 @@ class ConfigurationContentTypeTests: XCTestCase {
         // There is no public way to build a RenderingInfo.
         //
         // Thus we'll use a rendering object that will provide us with one:
-        
-        DefaultConfiguration.contentType = .text
-        
-        let testedTemplate = try! Template(string: "")
+        var configuration = Configuration.default
+        configuration.contentType = .text
+
+        let testedTemplate = try! Template(string: "", configuration: configuration)
         var testedContentType: ContentType?
         let render = { (info: RenderingInfo) -> Rendering in
             let rendering = try testedTemplate.render(info.context)
@@ -103,53 +98,8 @@ class ConfigurationContentTypeTests: XCTestCase {
     }
     
     func testDefaultConfigurationContentTypeHTMLHasSectionTagRenderHTML() {
-        DefaultConfiguration.contentType = .html
-        
-        var testedContentType: ContentType?
-        let render = { (info: RenderingInfo) -> Rendering in
-            let rendering = try info.tag.render(info.context)
-            testedContentType = rendering.contentType
-            return rendering
-        }
-        
-        let template = try! Template(string: "{{#.}}{{/.}}")
-        _ = try! template.render(render)
-        XCTAssertEqual(testedContentType!, ContentType.html)
-    }
-    
-    func testDefaultConfigurationContentTypeTextHasSectionTagRenderText() {
-        DefaultConfiguration.contentType = .text
-        
-        var testedContentType: ContentType?
-        let render = { (info: RenderingInfo) -> Rendering in
-            let rendering = try info.tag.render(info.context)
-            testedContentType = rendering.contentType
-            return rendering
-        }
-        
-        let template = try! Template(string: "{{#.}}{{/.}}")
-        _ = try! template.render(render)
-        XCTAssertEqual(testedContentType!, ContentType.text)
-    }
-    
-    func testDefaultConfigurationContentTypeHTMLHasVariableTagRenderHTML() {
-        DefaultConfiguration.contentType = .html
-        
-        var testedContentType: ContentType?
-        let render = { (info: RenderingInfo) -> Rendering in
-            let rendering = try info.tag.render(info.context)
-            testedContentType = rendering.contentType
-            return rendering
-        }
-        
-        let template = try! Template(string: "{{.}}")
-        _ = try! template.render(render)
-        XCTAssertEqual(testedContentType!, ContentType.html)
-    }
-    
-    func testDefaultConfigurationContentTypeTextHasVariableTagRenderText() {
-        DefaultConfiguration.contentType = .text
-        
+        var configuration = Configuration.default
+        configuration.contentType = .html
 
         var testedContentType: ContentType?
         let render = { (info: RenderingInfo) -> Rendering in
@@ -158,32 +108,83 @@ class ConfigurationContentTypeTests: XCTestCase {
             return rendering
         }
         
-        let template = try! Template(string: "{{.}}")
+        let template = try! Template(string: "{{#.}}{{/.}}", configuration: configuration)
+        _ = try! template.render(render)
+        XCTAssertEqual(testedContentType!, ContentType.html)
+    }
+    
+    func testDefaultConfigurationContentTypeTextHasSectionTagRenderText() {
+        var configuration = Configuration.default
+        configuration.contentType = .text
+
+        var testedContentType: ContentType?
+        let render = { (info: RenderingInfo) -> Rendering in
+            let rendering = try info.tag.render(info.context)
+            testedContentType = rendering.contentType
+            return rendering
+        }
+        
+        let template = try! Template(string: "{{#.}}{{/.}}", configuration: configuration)
+        _ = try! template.render(render)
+        XCTAssertEqual(testedContentType!, ContentType.text)
+    }
+    
+    func testDefaultConfigurationContentTypeHTMLHasVariableTagRenderHTML() {
+        var configuration = Configuration.default
+        configuration.contentType = .html
+
+        var testedContentType: ContentType?
+        let render = { (info: RenderingInfo) -> Rendering in
+            let rendering = try info.tag.render(info.context)
+            testedContentType = rendering.contentType
+            return rendering
+        }
+        
+        let template = try! Template(string: "{{.}}", configuration: configuration)
+        _ = try! template.render(render)
+        XCTAssertEqual(testedContentType!, ContentType.html)
+    }
+    
+    func testDefaultConfigurationContentTypeTextHasVariableTagRenderText() {
+        var configuration = Configuration.default
+        configuration.contentType = .text
+
+        var testedContentType: ContentType?
+        let render = { (info: RenderingInfo) -> Rendering in
+            let rendering = try info.tag.render(info.context)
+            testedContentType = rendering.contentType
+            return rendering
+        }
+        
+        let template = try! Template(string: "{{.}}", configuration: configuration)
         _ = try! template.render(render)
         XCTAssertEqual(testedContentType!, ContentType.text)
     }
     
     func testPragmaContentTypeTextOverridesDefaultConfiguration() {
-        DefaultConfiguration.contentType = .html
-        let template = try! Template(string:"{{%CONTENT_TYPE:TEXT}}{{.}}")
+        var configuration = Configuration.default
+        configuration.contentType = .html
+        let template = try! Template(string:"{{%CONTENT_TYPE:TEXT}}{{.}}", configuration: configuration)
         let rendering = try! template.render("&")
         XCTAssertEqual(rendering, "&")
     }
     
     func testPragmaContentTypeHTMLOverridesDefaultConfiguration() {
-        DefaultConfiguration.contentType = .text
-        let template = try! Template(string:"{{%CONTENT_TYPE:HTML}}{{.}}")
+        var configuration = Configuration.default
+        configuration.contentType = .text
+        let template = try! Template(string:"{{%CONTENT_TYPE:HTML}}{{.}}", configuration: configuration)
         let rendering = try! template.render("&")
         XCTAssertEqual(rendering, "&amp;")
     }
     
     func testDefaultRepositoryConfigurationHasDefaultConfigurationContentType() {
-        DefaultConfiguration.contentType = .html
-        var repo = TemplateRepository()
+        var configuration = Configuration.default
+        configuration.contentType = .html
+        var repo = TemplateRepository(configuration: configuration)
         XCTAssertEqual(repo.configuration.contentType, ContentType.html)
         
-        DefaultConfiguration.contentType = .text
-        repo = TemplateRepository()
+        configuration.contentType = .text
+        repo = TemplateRepository(configuration: configuration)
         XCTAssertEqual(repo.configuration.contentType, ContentType.text)
     }
     
@@ -224,7 +225,6 @@ class ConfigurationContentTypeTests: XCTestCase {
     }
 
     func testRepositoryConfigurationContentTypeTextOverridesDefaultConfigurationContentTypeHTMLWhenSettingTheWholeConfiguration() {
-        DefaultConfiguration.contentType = .html
         var configuration = Configuration()
         configuration.contentType = .text
         let repository = TemplateRepository()
@@ -235,7 +235,6 @@ class ConfigurationContentTypeTests: XCTestCase {
     }
     
     func testRepositoryConfigurationContentTypeTextOverridesDefaultConfigurationContentTypeHTMLWhenUpdatingRepositoryConfiguration() {
-        DefaultConfiguration.contentType = .html
         let repository = TemplateRepository()
         repository.configuration.contentType = .text
         let template = try! repository.template(string: "{{.}}")
@@ -244,7 +243,6 @@ class ConfigurationContentTypeTests: XCTestCase {
     }
     
     func testRepositoryConfigurationContentTypeHTMLOverridesDefaultConfigurationContentTypeTextWhenSettingTheWholeConfiguration() {
-        DefaultConfiguration.contentType = .text
         var configuration = Configuration()
         configuration.contentType = .html
         let repository = TemplateRepository()
@@ -255,7 +253,6 @@ class ConfigurationContentTypeTests: XCTestCase {
     }
     
     func testRepositoryConfigurationContentTypeHTMLOverridesDefaultConfigurationContentTypeTextWhenUpdatingRepositoryConfiguration() {
-        DefaultConfiguration.contentType = .text
         let repository = TemplateRepository()
         repository.configuration.contentType = .html
         let template = try! repository.template(string: "{{.}}")
@@ -304,8 +301,10 @@ class ConfigurationContentTypeTests: XCTestCase {
         
         var rendering = try! repository.template(string: "{{.}}").render("&")
         XCTAssertEqual(rendering, "&amp;")
-        
-        DefaultConfiguration.contentType = .text
+
+        var configuration = Configuration.default
+        configuration.contentType = .text
+        repository.configuration = configuration
         rendering = try! repository.template(string: "{{.}}").render("&")
         XCTAssertEqual(rendering, "&amp;")
     }

--- a/Tests/Public/ConfigurationTests/ConfigurationTagDelimitersTests.swift
+++ b/Tests/Public/ConfigurationTests/ConfigurationTagDelimitersTests.swift
@@ -26,43 +26,38 @@ import Mustache
 
 class ConfigurationTagDelimitersTests: XCTestCase {
    
-    override func tearDown() {
-        super.tearDown()
-        DefaultConfiguration = Configuration()
-    }
-        
     func testFactoryConfigurationHasTagDelimitersRegardlessOfDefaultConfiguration() {
-        DefaultConfiguration.tagDelimiterPair = ("<%", "%>")
-        
-        let configuration = Configuration()
-        XCTAssertEqual(configuration.tagDelimiterPair.0, "{{")
-        XCTAssertEqual(configuration.tagDelimiterPair.1, "}}")
+        XCTAssertEqual(Configuration.default.tagDelimiterPair.0, "{{")
+        XCTAssertEqual(Configuration.default.tagDelimiterPair.1, "}}")
     }
     
     func testDefaultConfigurationTagDelimiters() {
-        DefaultConfiguration.tagDelimiterPair = ("<%", "%>")
-        
-        let template = try! Template(string: "<%subject%>")
+        var configuration = Configuration.default
+        configuration.tagDelimiterPair = ("<%", "%>")
+
+        let template = try! Template(string: "<%subject%>", configuration: configuration)
         let rendering = try! template.render(["subject": "---"])
         XCTAssertEqual(rendering, "---")
     }
     
     func testSetDelimitersTagOverridesDefaultConfigurationDelimiters() {
-        DefaultConfiguration.tagDelimiterPair = ("<%", "%>")
-        
-        let template = try! Template(string: "<%=[[ ]]=%>[[subject]]")
+        var configuration = Configuration.default
+        configuration.tagDelimiterPair = ("<%", "%>")
+
+        let template = try! Template(string: "<%=[[ ]]=%>[[subject]]", configuration: configuration)
         let rendering = try! template.render(["subject": "---"])
         XCTAssertEqual(rendering, "---")
     }
     
     func testDefaultRepositoryConfigurationHasDefaultConfigurationTagDelimiters() {
-        DefaultConfiguration.tagDelimiterPair = ("<%", "%>")
-        
-        let repository = TemplateRepository()
+        var configuration = Configuration.default
+        configuration.tagDelimiterPair = ("<%", "%>")
+
+        let repository = TemplateRepository(configuration: configuration)
         XCTAssertEqual(repository.configuration.tagDelimiterPair.0, "<%")
         XCTAssertEqual(repository.configuration.tagDelimiterPair.1, "%>")
 
-        DefaultConfiguration.tagDelimiterPair = ("[[", "]]")
+        configuration.tagDelimiterPair = ("[[", "]]")
         XCTAssertEqual(repository.configuration.tagDelimiterPair.0, "<%")
         XCTAssertEqual(repository.configuration.tagDelimiterPair.1, "%>")
     }
@@ -89,8 +84,6 @@ class ConfigurationTagDelimitersTests: XCTestCase {
     }
     
     func testRepositoryConfigurationTagDelimitersOverridesDefaultConfigurationTagDelimitersWhenSettingTheWholeConfiguration() {
-        DefaultConfiguration.tagDelimiterPair = ("<%", "%>")
-        
         var configuration = Configuration()
         configuration.tagDelimiterPair = ("[[", "]]")
         let repository = TemplateRepository()
@@ -102,8 +95,6 @@ class ConfigurationTagDelimitersTests: XCTestCase {
     }
     
     func testRepositoryConfigurationTagDelimitersOverridesDefaultConfigurationTagDelimitersWhenUpdatingRepositoryConfiguration() {
-        DefaultConfiguration.tagDelimiterPair = ("<%", "%>")
-        
         let repository = TemplateRepository()
         repository.configuration.tagDelimiterPair = ("[[", "]]")
         
@@ -137,8 +128,10 @@ class ConfigurationTagDelimitersTests: XCTestCase {
         
         var rendering = try! repository.template(string: "{{foo}}<%foo%>").render(["foo": "foo"])
         XCTAssertEqual(rendering, "foo<%foo%>")
-        
-        DefaultConfiguration.tagDelimiterPair = ("<%", "%>")
+
+        var configuration = Configuration.default
+        configuration.tagDelimiterPair = ("<%", "%>")
+        repository.configuration = configuration
         rendering = try! repository.template(string: "{{foo}}<%foo%>").render(["foo": "foo"])
         XCTAssertEqual(rendering, "foo<%foo%>")
     }

--- a/Tests/Public/DocumentationTests/ReadMeTests.swift
+++ b/Tests/Public/DocumentationTests/ReadMeTests.swift
@@ -45,12 +45,7 @@ fileprivate func > <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
 
 
 class ReadMeTests: XCTestCase {
-    
-    override func tearDown() {
-        super.tearDown()
-        DefaultConfiguration = Configuration()
-    }
-    
+
     func testReadmeExample1() {
         let testBundle = Bundle.ofFileDirectory(filePath: #file)
         let template = try! Template(named: "ReadMeExample1", bundle: testBundle)
@@ -82,14 +77,14 @@ class ReadMeTests: XCTestCase {
         
         
         // Register the pluralize filter for all Mustache renderings:
-        
-        Mustache.DefaultConfiguration.register(pluralizeFilter, forKey: "pluralize")
-        
+        var configuration = Configuration.default
+        configuration.register(pluralizeFilter, forKey: "pluralize")
+
         
         // I have 3 cats.
         
         let testBundle = Bundle.ofFileDirectory(filePath: #file)
-        let template = try! Template(named: "ReadMeExample2", bundle: testBundle)
+        let template = try! Template(named: "ReadMeExample2", bundle: testBundle, configuration: configuration)
         let data = ["cats": ["Kitty", "Pussy", "Melba"]]
         let rendering = try! template.render(data)
         XCTAssertEqual(rendering, "I have 3 cats.")


### PR DESCRIPTION
fix #98 

Addresses Concurrency warnings caused by Swift 6. This PR contains a breaking change.

The `DefaultConfiguration` has been deprecated as a breaking change. The following functions, whose behavior could be changed by changing the `DefaultConfiguration`, can now pass `Configuration` as an argument. The following modules are affected.

- `TemplateRepository`
- `Template`
- `Lambda`

Rewrote globally declared non-Sendable variables to static computed properties and global function declarations. The following modules are affected.

- `EmptyBox`
- `EachFilter`
- `ZipFilter`
- `DefaultConfiguration`

Immutable and static properties that are not Sendable have been rewritten as computed properties. The following modules are affected.

- `StandardLibrary`

`MustacheError.Kind` is now `Sendable` compatible.