### PR TITLE
Fix problem where some constructors in Template could block the main thread

### DIFF
--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -95,7 +95,7 @@ final public class Template {
     /// - parameter encoding: The encoding of the template resource.
     /// - parameter configuration: The configuration for rendering. If the configuration is not specified, `Configuration.default` is used.
     /// - throws: MustacheError
-    @available(iOS 15.0, macOS 12.0, *)
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
     public convenience init(URL: Foundation.URL, encoding: String.Encoding = .utf8, configuration: Configuration = .default) async throws {
         let baseURL = URL.deletingLastPathComponent()
         let templateExtension = URL.pathExtension

--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -82,7 +82,29 @@ final public class Template {
         let templateAST = try repository.templateAST(named: templateName)
         self.init(repository: repository, templateAST: templateAST, baseContext: repository.configuration.baseContext)
     }
-    
+
+    /// Creates a template from the contents of a URL.
+    ///
+    /// Eventual partial tags in the template refer to sibling templates using
+    /// the same extension.
+    ///
+    ///     // `{{>partial}}` in `file://path/to/template.txt` loads `file://path/to/partial.txt`:
+    ///     let template = try! Template(URL: "file://path/to/template.txt")
+    ///
+    /// - parameter URL: The URL of the template.
+    /// - parameter encoding: The encoding of the template resource.
+    /// - parameter configuration: The configuration for rendering. If the configuration is not specified, `Configuration.default` is used.
+    /// - throws: MustacheError
+    @available(iOS 15.0, *)
+    public convenience init(URL: Foundation.URL, encoding: String.Encoding = .utf8, configuration: Configuration = .default) async throws {
+        let baseURL = URL.deletingLastPathComponent()
+        let templateExtension = URL.pathExtension
+        let templateName = (URL.lastPathComponent as NSString).deletingPathExtension
+        let repository = TemplateRepository(baseURL: baseURL, templateExtension: templateExtension, encoding: encoding, configuration: configuration)
+        let templateAST = try await repository.templateAST(named: templateName)
+        self.init(repository: repository, templateAST: templateAST, baseContext: repository.configuration.baseContext)
+    }
+
     /// Creates a template from a bundle resource.
     /// 
     /// Eventual partial tags in the template refer to template resources using

--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -95,7 +95,7 @@ final public class Template {
     /// - parameter encoding: The encoding of the template resource.
     /// - parameter configuration: The configuration for rendering. If the configuration is not specified, `Configuration.default` is used.
     /// - throws: MustacheError
-    @available(iOS 15.0, *)
+    @available(iOS 15.0, macOS 12.0, *)
     public convenience init(URL: Foundation.URL, encoding: String.Encoding = .utf8, configuration: Configuration = .default) async throws {
         let baseURL = URL.deletingLastPathComponent()
         let templateExtension = URL.pathExtension

--- a/Sources/TemplateRepository.swift
+++ b/Sources/TemplateRepository.swift
@@ -76,14 +76,6 @@ public protocol TemplateRepositoryDataSource {
     /// - throws: MustacheError
     /// - returns: A Mustache template string.
     func templateStringForTemplateID(_ templateID: TemplateID) throws -> String
-
-    /// Returns the Mustache template string that matches the template ID.
-    ///
-    /// - parameter templateID: The template ID of the template.
-    /// - throws: MustacheError
-    /// - returns: A Mustache template string.
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
-    func templateStringForTemplateID(_ templaetID: TemplateID) async throws -> String
 }
 
 /// A template repository represents a set of sibling templates and partials.

--- a/Sources/TemplateRepository.swift
+++ b/Sources/TemplateRepository.swift
@@ -82,7 +82,7 @@ public protocol TemplateRepositoryDataSource {
     /// - parameter templateID: The template ID of the template.
     /// - throws: MustacheError
     /// - returns: A Mustache template string.
-    @available(iOS 15.0, *)
+    @available(iOS 15.0, macOS 12.0, *)
     func templateStringForTemplateID(_ templaetID: TemplateID) async throws -> String
 }
 
@@ -353,7 +353,7 @@ final public class TemplateRepository {
         }
     }
 
-    @available(iOS 15.0, *)
+    @available(iOS 15.0, macOS 12.0, *)
     func templateAST(named name: String, relativeToTemplateID baseTemplateID: TemplateID? = nil) async throws -> TemplateAST {
         guard let dataSource = self.dataSource else {
             throw MustacheError(kind: .templateNotFound, message: "Missing dataSource", templateID: baseTemplateID)
@@ -510,7 +510,7 @@ final public class TemplateRepository {
             return try NSString(contentsOf: URL(string: templateID)!, encoding: encoding.rawValue) as String
         }
 
-        @available(iOS 15.0, *)
+        @available(iOS 15.0, macOS 12.0, *)
         func templateStringForTemplateID(_ templateID: TemplateID) async throws -> String {
             let (data, _) = try await URLSession.shared.data(from: URL(string: templateID)!)
 

--- a/Sources/TemplateRepository.swift
+++ b/Sources/TemplateRepository.swift
@@ -82,7 +82,7 @@ public protocol TemplateRepositoryDataSource {
     /// - parameter templateID: The template ID of the template.
     /// - throws: MustacheError
     /// - returns: A Mustache template string.
-    @available(iOS 15.0, macOS 12.0, *)
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
     func templateStringForTemplateID(_ templaetID: TemplateID) async throws -> String
 }
 
@@ -353,7 +353,7 @@ final public class TemplateRepository {
         }
     }
 
-    @available(iOS 15.0, macOS 12.0, *)
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
     func templateAST(named name: String, relativeToTemplateID baseTemplateID: TemplateID? = nil) async throws -> TemplateAST {
         guard let dataSource = self.dataSource else {
             throw MustacheError(kind: .templateNotFound, message: "Missing dataSource", templateID: baseTemplateID)
@@ -510,7 +510,7 @@ final public class TemplateRepository {
             return try NSString(contentsOf: URL(string: templateID)!, encoding: encoding.rawValue) as String
         }
 
-        @available(iOS 15.0, macOS 12.0, *)
+        @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
         func templateStringForTemplateID(_ templateID: TemplateID) async throws -> String {
             let (data, _) = try await URLSession.shared.data(from: URL(string: templateID)!)
 

--- a/Tests/Public/TemplateTests/TemplateFromMethodsTests/TemplateFromMethodsTests.swift
+++ b/Tests/Public/TemplateTests/TemplateFromMethodsTests/TemplateFromMethodsTests.swift
@@ -275,7 +275,7 @@ class TemplateFromMethodsTests: XCTestCase {
     }
 }
 
-@available(iOS 15.0, macOS 12.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 extension TemplateFromMethodsTests {
     func testTemplateFromURL() async {
         let template = try! await Template(URL: templateURL)

--- a/Tests/Public/TemplateTests/TemplateFromMethodsTests/TemplateFromMethodsTests.swift
+++ b/Tests/Public/TemplateTests/TemplateFromMethodsTests/TemplateFromMethodsTests.swift
@@ -274,3 +274,61 @@ class TemplateFromMethodsTests: XCTestCase {
         }
     }
 }
+
+@available(iOS 15.0, *)
+extension TemplateFromMethodsTests {
+    func testTemplateFromURL() async {
+        let template = try! await Template(URL: templateURL)
+        let keyedSubscript = makeKeyedSubscriptFunction("foo")
+        let rendering = try! template.render(MustacheBox(keyedSubscript: keyedSubscript))
+        XCTAssertEqual(valueForStringPropertyInRendering(rendering)!, "foo")
+    }
+
+    func testParserErrorFromURL() async {
+        do {
+            let _ = try await Template(URL: parserErrorTemplateURL)
+            XCTFail("Expected MustacheError")
+        } catch let error as MustacheError {
+            XCTAssertEqual(error.kind, MustacheError.Kind.parseError)
+            XCTAssertTrue(error.description.range(of: "line 2") != nil)
+            XCTAssertTrue(error.description.range(of: parserErrorTemplatePath) != nil)
+        } catch {
+            XCTFail("Expected MustacheError")
+        }
+
+        do {
+            let _ = try await Template(URL: parserErrorTemplateWrapperURL)
+            XCTFail("Expected MustacheError")
+        } catch let error as MustacheError {
+            XCTAssertEqual(error.kind, MustacheError.Kind.parseError)
+            XCTAssertTrue(error.description.range(of: "line 2") != nil)
+            XCTAssertTrue(error.description.range(of: parserErrorTemplatePath) != nil)
+        } catch {
+            XCTFail("Expected MustacheError")
+        }
+    }
+
+    func testCompilerErrorFromURL() async {
+        do {
+            let _ = try await Template(URL: compilerErrorTemplateURL)
+            XCTFail("Expected MustacheError")
+        } catch let error as MustacheError {
+            XCTAssertEqual(error.kind, MustacheError.Kind.parseError)
+            XCTAssertTrue(error.description.range(of: "line 2") != nil)
+            XCTAssertTrue(error.description.range(of: compilerErrorTemplatePath) != nil)
+        } catch {
+            XCTFail("Expected MustacheError")
+        }
+
+        do {
+            let _ = try await Template(URL: compilerErrorTemplateWrapperURL)
+            XCTFail("Expected MustacheError")
+        } catch let error as MustacheError {
+            XCTAssertEqual(error.kind, MustacheError.Kind.parseError)
+            XCTAssertTrue(error.description.range(of: "line 2") != nil)
+            XCTAssertTrue(error.description.range(of: compilerErrorTemplatePath) != nil)
+        } catch {
+            XCTFail("Expected MustacheError")
+        }
+    }
+}

--- a/Tests/Public/TemplateTests/TemplateFromMethodsTests/TemplateFromMethodsTests.swift
+++ b/Tests/Public/TemplateTests/TemplateFromMethodsTests/TemplateFromMethodsTests.swift
@@ -275,7 +275,7 @@ class TemplateFromMethodsTests: XCTestCase {
     }
 }
 
-@available(iOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, *)
 extension TemplateFromMethodsTests {
     func testTemplateFromURL() async {
         let template = try! await Template(URL: templateURL)


### PR DESCRIPTION
User can use constructors that pass `URL` when initializing a `Template` object. This constructor can generate a `Template` object from a string that exists not only locally, but also server-side.

Since this constructor calls `NSString(contentsOf:encoding)` internally, it could block the calling thread if the given URL is remote.

This change adds a constructor for a `Template` object that can be called in async for iOS 15 and above. This constructor allows remote resources to be used without blocking the calling thread.