### PR TITLE
fix: update the podspec and the readme

### DIFF
--- a/GRMustache.swift.podspec
+++ b/GRMustache.swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name     = 'GRMustache.swift'
-	s.version  = '5.0.0'
+	s.version  = '5.0.1'
 	s.license  = { :type => 'MIT', :file => 'LICENSE' }
 	s.summary  = 'Flexible Mustache templates for Swift.'
 	s.homepage = 'https://github.com/groue/GRMustache.swift'

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ To use GRMustache.swift with the Swift Package Manager, add https://github.com/g
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/groue/GRMustache.swift", from: "5.0.0")
+    .package(url: "https://github.com/groue/GRMustache.swift", from: "5.0.1")
 ]
 ```
 


### PR DESCRIPTION
Small thing, just bumping the podspec to match the latest. Maybe there could be an automation for this

Also when I try to install from Cocoapods, 4.0.1 is the highest it ever finds, had to mention the package directly. Not sure why, especially since that page is very out dated https://cocoapods.org/pods/GRMustache.swift