### PR TITLE
fix: update Foundation.swift for cocoa pods

### DIFF
--- a/GRMustache.swift.podspec
+++ b/GRMustache.swift.podspec
@@ -8,9 +8,9 @@ Pod::Spec.new do |s|
 	s.source   = { :git => 'https://github.com/groue/GRMustache.swift.git', :tag => s.version }
 	s.source_files = 'Sources/**/*.{h,m,swift}', 'ObjC/**/*.{h,m,swift}'
 	s.module_name = 'Mustache'
-	s.swift_version = '5.0'
-	s.ios.deployment_target = '8.0'
-	s.osx.deployment_target = '10.10'
+	s.swift_version = '5.9'
+	s.ios.deployment_target = '11.0'
+	s.osx.deployment_target = '10.11'
 	s.tvos.deployment_target = '9.0'
 	s.requires_arc = true
 	s.framework = 'Foundation'

--- a/Sources/Foundation.swift
+++ b/Sources/Foundation.swift
@@ -21,7 +21,9 @@
 // THE SOFTWARE.
 
 import Foundation
+#if canImport(GRMustacheKeyAccess)
 import GRMustacheKeyAccess
+#endif
 
 /// GRMustache provides built-in support for rendering `NSObject`.
 extension NSObject : MustacheBoxable {


### PR DESCRIPTION
Bit of a doozy, but basically, when it comes to SPM, the `GRMustacheKeyAccess` is a package that you import, but when it comes to Cocoapods, this is already bundled next to it and is NOT a separate package, so when you call import, it will fail, which means you can't build when using cocoa pods.

This PR adds a check to see if that even exists before trying to import it, addressing the issue for both SPM and Cocoapods (tried both locally but feel free to try as well)