### PR TITLE
automate release for cocoapods via github actions

### DIFF
--- a/.github/workflows/publish-to-cocoapods.yml
+++ b/.github/workflows/publish-to-cocoapods.yml
@@ -23,4 +23,3 @@ jobs:
           pod trunk push --allow-warnings
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-          RELEASE_VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/publish-to-cocoapods.yml
+++ b/.github/workflows/publish-to-cocoapods.yml
@@ -1,0 +1,26 @@
+name: publish-to-cocoapods
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Install Cocoapods
+        run: gem install cocoapods
+
+      - name: Publish to Cocoapods registry
+        run: |
+          set -eo pipefail
+          pod lib lint --allow-warnings
+          pod trunk push --allow-warnings
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}

--- a/GRMustache.swift.podspec
+++ b/GRMustache.swift.podspec
@@ -1,6 +1,9 @@
+version = ENV["RELEASE_VERSION"]
+exit 1 if version.to_s.empty?
+
 Pod::Spec.new do |s|
 	s.name     = 'GRMustache.swift'
-	s.version  = '5.0.1'
+	s.version  = version
 	s.license  = { :type => 'MIT', :file => 'LICENSE' }
 	s.summary  = 'Flexible Mustache templates for Swift.'
 	s.homepage = 'https://github.com/groue/GRMustache.swift'

--- a/GRMustache.swift.podspec
+++ b/GRMustache.swift.podspec
@@ -1,9 +1,6 @@
-version = ENV["RELEASE_VERSION"]
-exit 1 if version.to_s.empty?
-
 Pod::Spec.new do |s|
 	s.name     = 'GRMustache.swift'
-	s.version  = version
+	s.version  = 5.0.1
 	s.license  = { :type => 'MIT', :file => 'LICENSE' }
 	s.summary  = 'Flexible Mustache templates for Swift.'
 	s.homepage = 'https://github.com/groue/GRMustache.swift'

--- a/GRMustache.swift.podspec
+++ b/GRMustache.swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name     = 'GRMustache.swift'
-	s.version  = 5.0.1
+	s.version  = '5.0.1'
 	s.license  = { :type => 'MIT', :file => 'LICENSE' }
 	s.summary  = 'Flexible Mustache templates for Swift.'
 	s.homepage = 'https://github.com/groue/GRMustache.swift'


### PR DESCRIPTION
This PR automates the publishing to CocoaPods using GitHub Actions. This action will attempt to release to CocoaPods whenever a new release is created, using the release’s `tag_name` as the version. Please note that the environment variable `COCOAPODS_TRUNK_TOKEN` must be specified.